### PR TITLE
feat: Invites CTA in the top bar → invite.scottylabs.org

### DIFF
--- a/apps/web/app/sections/home/Header.module.css
+++ b/apps/web/app/sections/home/Header.module.css
@@ -56,9 +56,10 @@
   height: 1.1em;
 }
 
-/* CTA to the events app (invite.scottylabs.org) — mirrors the primary Button
+/* CTA to ScottyLabs Invites (invite.scottylabs.org) — labeled "Invites" to
+   avoid confusion with the Events committee; mirrors the primary Button
    tokens (black-900, lg radius, scale hover) at header scale. */
-.events-button {
+.invites-button {
   display: flex;
   gap: 6px;
   align-items: center;
@@ -79,7 +80,7 @@
     }
   }
 }
-.events-button__icon {
+.invites-button__icon {
   height: 1.1em;
   filter: brightness(0) invert(1);
 }
@@ -89,14 +90,14 @@
     padding: 14px 16px;
   }
   .nav-button,
-  .events-button {
+  .invites-button {
     padding-inline: 10px;
   }
-  .events-button {
+  .invites-button {
     margin-left: 4px;
   }
   .nav-button__icon,
-  .events-button__icon {
+  .invites-button__icon {
     display: none;
   }
 }

--- a/apps/web/app/sections/home/Header.module.css
+++ b/apps/web/app/sections/home/Header.module.css
@@ -55,3 +55,48 @@
 .nav-button__icon {
   height: 1.1em;
 }
+
+/* CTA to the events app (invite.scottylabs.org) — mirrors the primary Button
+   tokens (black-900, lg radius, scale hover) at header scale. */
+.events-button {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-left: 10px;
+  padding: 10px 20px;
+  font-size: var(--text-base);
+  font-weight: 700;
+  color: var(--black-50);
+  background-color: var(--black-900);
+  border-radius: var(--border-radius-lg);
+  transition: 0.15s transform;
+  will-change: transform;
+
+  &:hover {
+    transform: scale(1.05);
+    &:active {
+      transform: scale(1.02);
+    }
+  }
+}
+.events-button__icon {
+  height: 1.1em;
+  filter: brightness(0) invert(1);
+}
+
+@media (max-width: 560px) {
+  .main-header-layout {
+    padding: 14px 16px;
+  }
+  .nav-button,
+  .events-button {
+    padding-inline: 10px;
+  }
+  .events-button {
+    margin-left: 4px;
+  }
+  .nav-button__icon,
+  .events-button__icon {
+    display: none;
+  }
+}

--- a/apps/web/app/sections/home/Header.tsx
+++ b/apps/web/app/sections/home/Header.tsx
@@ -13,11 +13,6 @@ const navLinks = [
     url: "/projects",
     text: "Projects",
   },
-  // {
-  //   icon: eventsIcon,
-  //   url: "/events",
-  //   text: "Events",
-  // },
   {
     icon: teamIcon,
     url: "/team",
@@ -63,6 +58,13 @@ function Header() {
               <div className={css["nav-button__text"]}>{text}</div>
             </NavLink>
           ))}
+          <a
+            className={css["events-button"]}
+            href="https://invite.scottylabs.org"
+          >
+            <img className={css["events-button__icon"]} src={eventsIcon} />
+            <div>Events</div>
+          </a>
         </nav>
       </div>
     </header>

--- a/apps/web/app/sections/home/Header.tsx
+++ b/apps/web/app/sections/home/Header.tsx
@@ -59,11 +59,11 @@ function Header() {
             </NavLink>
           ))}
           <a
-            className={css["events-button"]}
+            className={css["invites-button"]}
             href="https://invite.scottylabs.org"
           >
-            <img className={css["events-button__icon"]} src={eventsIcon} />
-            <div>Events</div>
+            <img className={css["invites-button__icon"]} src={eventsIcon} />
+            <div>Invites</div>
           </a>
         </nav>
       </div>


### PR DESCRIPTION
## What

Adds an on-brand **Invites** CTA to the site's top bar, linking to the new ScottyLabs Invites app at **https://invite.scottylabs.org** — the Luma-style event signup system (browse events, CMU magic-link signup, numbered Scotty Invite QR passes, organizer dashboards, door check-in).

This realizes the commented-out `Events` nav slot in `Header.tsx`, which was waiting for a destination. It's labeled **Invites** (matching the app's wordmark) rather than "Events" to avoid confusion with the Events committee.

## Design

- Black pill using the site's existing primary-button language: `--black-900` background, `--border-radius-lg` (40px), bold label, and the same `scale(1.05)` hover / `scale(1.02)` press animation as `components/Button`.
- Reuses the existing `events.svg` icon, inverted to white; sits at the end of the nav with a small gap so it reads as the header's single CTA (mirrors the header pattern on the Invites app side, which links back to scottylabs.org).
- ≤ 560px: header padding tightens and nav icons drop so all four items still fit on a 375px screen.

No new dependencies; two files touched (`Header.tsx`, `Header.module.css`). Screenshots shared in the rollout thread.

## Why now

invite.scottylabs.org is deployed and being CNAMEd; per the Invites handoff, the main site should cross-link to it from the top bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pc2Q33BL1qPU25GL7Eo6Hc
