### PR TITLE
Add Committees link to the site header

### DIFF
--- a/apps/web/app/sections/home/Header.tsx
+++ b/apps/web/app/sections/home/Header.tsx
@@ -6,6 +6,7 @@ import teamIcon from "../../assets/icons/team.svg";
 import projectsIcon from "../../assets/icons/projects.svg";
 import eventsIcon from "../../assets/icons/events.svg";
 import sponsorsIcon from "../../assets/icons/sponsors.svg";
+import commitIcon from "../../assets/icons/commit.svg";
 import { NavLink, useLocation } from "react-router";
 const navLinks = [
   {
@@ -63,6 +64,10 @@ function Header() {
               <div className={css["nav-button__text"]}>{text}</div>
             </NavLink>
           ))}
+          <a className={css["nav-button"]} href="https://committees.scottylabs.org">
+            <img className={css["nav-button__icon"]} src={commitIcon} />
+            <div className={css["nav-button__text"]}>Committees</div>
+          </a>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
Adds a **Committees** item to the main-site header nav, linking to the new committees recruiting portal at https://committees.scottylabs.org.

The portal is a standalone sibling app (own deployment + database) that mirrors the main site's chrome — header, hero conventions, fonts, buttons — and links back here, so the two sites read as one. This PR completes the loop in the other direction.

Implementation notes:
- Plain `<a>` rather than a `NavLink` since the target is an external origin; reuses the existing `nav-button` styles so hover/spacing match the other items.
- Icon is the repo's existing `commit.svg` (same one the portal uses for its active Committees nav state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LgpB9t53zDVJPrad5Qzr6